### PR TITLE
we need to shield wechaty_puppet"s **QueryFilter to user in wechaty

### DIFF
--- a/src/wechaty/user/contact.py
+++ b/src/wechaty/user/contact.py
@@ -77,7 +77,7 @@ class Contact(Accessory):
         return self.contact_id
 
     @classmethod
-    async def load(
+    def load(
             cls        : Type[Contact],
             contact_id : Optional[str],
             # *args,

--- a/src/wechaty/user/room.py
+++ b/src/wechaty/user/room.py
@@ -21,7 +21,8 @@ from ..accessory import Accessory
 if TYPE_CHECKING:
     from wechaty_puppet import (
         FileBox,
-        RoomQueryFilter as PuppetRoomQueryFilter
+        RoomQueryFilter as PuppetRoomQueryFilter,
+        RoomPayload
     )
     from .contact import Contact
     from .url_link import UrlLink
@@ -34,11 +35,19 @@ class RoomQueryFilter:
     """
     python-wechaty room query filter
     """
-    def transfer(self) -> PuppetRoomQueryFilter:
+    def transfer(self, query: str = None) -> PuppetRoomQueryFilter:
         """
         convert python-wechaty RoomQueryFilter to PuppetRoomQueryFilter
         """
         return PuppetRoomQueryFilter()
+
+    @classmethod
+    def to_query_filter(cls, query: str) -> RoomQueryFilter:
+        """
+        transfer str query filter to PuppetRoomQueryFilter
+        """
+        # TODO -> details in query filter
+        return RoomQueryFilter()
 
 
 class Room(Accessory, Sayable):
@@ -50,20 +59,14 @@ class Room(Accessory, Sayable):
     def __init__(self, room_id: str) -> None:
         """docs"""
         self.room_id = room_id
+        self.payload: Optional[RoomPayload] = None
 
-    async def say(
-        self,
-        text: str,
-        reply_to: Union[
-            str,
-            Contact,
-            List[Contact],
-            FileBox,
-            UrlLink,
-            MiniProgram]) -> Optional[Message]:
-        """
-        """
-        pass
+        if self.__class__ is Room:
+            raise Exception('Room class can not be instanciated directly!')
+
+        if self.puppet is None:
+            raise Exception(
+                'Room class can not be instanciated without a puppet!')
 
     @classmethod
     async def create(
@@ -124,29 +127,172 @@ class Room(Accessory, Sayable):
         return room_result
 
     @classmethod
-    def find(cls, query: Union[str, RoomQueryFilter]):
+    async def find(
+            cls,
+            query: Union[str, RoomQueryFilter] = None) -> Union[None, Room]:
         """
-        Try to find a room by filter: {topic: string | RegExp}. If get many, return the first one.
+        Try to find a room by filter: {topic: string | RegExp}. If get many,
+        return the first one.
         :return:
         """
-        raise NotImplementedError
+        log.info('Room find <%s>', json.dumps(query))
+
+        room_query = None
+        if isinstance(query, str):
+            room_query = RoomQueryFilter.to_query_filter(query)
+
+        rooms = await cls.find_all(room_query)
+
+        if rooms is None or len(rooms) < 1:
+            return None
+
+        if len(rooms) > 1:
+            log.warn('Room find() got more than one(%d) result', len(rooms))
+
+        for index, room in enumerate(rooms):
+            valid = await cls.get_puppet().room_validate(room.room_id)
+
+            if valid:
+                log.warn(
+                    'Room find() confirm room[#%d] with id=%d '
+                    'is valid result, return it.',
+                    index,
+                    room.room_id
+                )
+                return room
+            else:
+                log.info(
+                    'Room find() confirm room[#%d] with id=%d '
+                    'is INVALID result, try next',
+                    index,
+                    room.room_id
+                )
+        log.info('Room find() got %d rooms but no one is valid.', len(rooms))
+        return None
 
     @classmethod
     def load(cls, room_id: str) -> Room:
         """
-        doc
+        dynamic load room instance
         """
-        return Room(room_id)
+        if room_id in cls._pool:
+            room = cls._pool.get(room_id)
+            if room is None:
+                raise Exception('room not found')
+            return room
 
-    async def ready(self):
-        """
+        new_room = cls(room_id)
+        cls._pool[room_id] = new_room
+        return new_room
 
-        :return:
+    def __str__(self):
         """
-        pass
+        string format for room instance
+        """
+        if self.payload is None:
+            return self.__class__.__name__
+
+        if self.payload.topic is None:
+            return 'loading ...'
+
+        return 'Room <%s>' % self.payload.topic
+
+    def is_ready(self) -> bool:
+        """
+        check if room's payload is ready
+        """
+        return self.payload is not None
+
+    async def ready(self, force_sync=False):
+        """
+        Please not to use `ready()` at the user land.
+        """
+        if self.is_ready():
+           return
+
+        if force_sync:
+            await self.puppet.room_payload_dirty(self.room_id)
+            await self.puppet.room_member_payload_dirty(self.room_id)
+
+        self.payload = self.puppet.room_payload(self.room_id)
+
+        if self.payload is None:
+            raise Exception('Room Payload can"t be ready')
+
+        member_ids = await self.puppet.room_members(self.room_id)
+
+        contacts = [
+            self.wechaty.Contact.load(member_id) for member_id in member_ids]
+
+        for contact in contacts:
+            try:
+                contact.ready()
+            except Exception as exception:
+                log.error(
+                    'Room ready() member.ready() rejection: %s', exception
+                )
+
+    async def say(
+            self,
+            some_thing: Union[str, Contact, FileBox, MiniProgram, UrlLink],
+            *args
+    ) -> Union[None, Message]:
+        """
+        Room Say(%s, %s)
+        """
+        log.info("Room say <%s, %s>", some_thing, args)
+
+        msg_id = None
+
+        # TODO -> if is str: logic should be viewed
+        if isinstance(some_thing, FileBox):
+            msg_id = await self.puppet.message_send_file(
+                self.room_id, some_thing
+            )
+        elif isinstance(some_thing, Contact):
+            msg_id = await self.puppet.message_send_contact(
+                # pytype: disable=attribute-error
+                self.room_id, some_thing.contact_id
+            )
+        elif isinstance(some_thing, UrlLink):
+            msg_id = await self.puppet.message_send_url(
+                # pytype: disable=attribute-error
+                self.room_id, some_thing.payload
+            )
+        elif isinstance(some_thing, MiniProgram):
+            msg_id = await self.puppet.message_send_mini_program(
+                # pytype: disable=attribute-error
+                self.room_id, some_thing.payload
+            )
+        else:
+            raise Exception('arg unsupported: ' + some_thing)
+
+        if msg_id is not None:
+            msg = self.wechaty.Message.load(msg_id)
+            await msg.ready()
+            return msg
+        return None
+
+    """
+    TODO -> sayTemplateStringsArray
+    """
+
+    """
+    TODO -> Event emit : on
+    """
+
+    async def add(self, contact: Contact):
+        """
+        Add contact in a room
+        """
+        log.info('Room add <%s>', contact)
+
+        await self.puppet.room_add(self.room_id, contact.contact_id)
 
     async def quit(self) -> None:
-        """docs"""
+        """
+        Add contact in a room
+        """
         pass
 
     async def alias(self, member: Contact) -> Optional[str]:

--- a/src/wechaty/user/room.py
+++ b/src/wechaty/user/room.py
@@ -21,12 +21,24 @@ from ..accessory import Accessory
 if TYPE_CHECKING:
     from wechaty_puppet import (
         FileBox,
-        RoomQueryFilter
+        RoomQueryFilter as PuppetRoomQueryFilter
     )
     from .contact import Contact
     from .url_link import UrlLink
     from .mini_program import MiniProgram
     from .message import Message
+
+
+# pylint: disable=R0903
+class RoomQueryFilter:
+    """
+    python-wechaty room query filter
+    """
+    def transfer(self) -> PuppetRoomQueryFilter:
+        """
+        convert python-wechaty RoomQueryFilter to PuppetRoomQueryFilter
+        """
+        return PuppetRoomQueryFilter()
 
 
 class Room(Accessory, Sayable):
@@ -40,24 +52,24 @@ class Room(Accessory, Sayable):
         self.room_id = room_id
 
     async def say(
-            self,
-            text: str,
-            reply_to: Union[
-                str,
-                Contact,
-                List[Contact],
-                FileBox,
-                UrlLink,
-                MiniProgram]) -> Optional[Message]:
+        self,
+        text: str,
+        reply_to: Union[
+            str,
+            Contact,
+            List[Contact],
+            FileBox,
+            UrlLink,
+            MiniProgram]) -> Optional[Message]:
         """
         """
         pass
 
     @classmethod
     async def create(
-            cls,
-            contacts: List[Contact],
-            topic: str = None) -> Room:
+        cls,
+        contacts: List[Contact],
+        topic: str = None) -> Room:
         """
         create room instance
         """
@@ -92,7 +104,9 @@ class Room(Accessory, Sayable):
         """
         log.info('Room find_all <%s>', json.dumps(query))
 
-        room_ids = await cls.get_puppet().room_search(query)
+        puppet_query = query.transfer() if query is not None else None
+        room_ids = await cls.get_puppet().room_search(puppet_query)
+
         rooms = [cls.load(room_id) for room_id in room_ids]
 
         room_result = []
@@ -108,6 +122,14 @@ class Room(Accessory, Sayable):
                     exception.args
                 )
         return room_result
+
+    @classmethod
+    def find(cls, query: Union[str, RoomQueryFilter]):
+        """
+        Try to find a room by filter: {topic: string | RegExp}. If get many, return the first one.
+        :return:
+        """
+        raise NotImplementedError
 
     @classmethod
     def load(cls, room_id: str) -> Room:

--- a/src/wechaty_puppet/__init__.py
+++ b/src/wechaty_puppet/__init__.py
@@ -21,7 +21,8 @@ from .message import (
     MessageType,
 )
 from .room import (
-    RoomQueryFilter
+    RoomQueryFilter,
+    RoomPayload
 )
 from .mini_program import (
     MiniProgramPayload
@@ -45,6 +46,7 @@ __all__ = [
     'UrlLinkPayload',
 
     'RoomQueryFilter',
+    'RoomPayload',
 
     'MiniProgramPayload'
 ]

--- a/src/wechaty_puppet/puppet.py
+++ b/src/wechaty_puppet/puppet.py
@@ -40,7 +40,8 @@ from .message import (
 )
 
 from .room import (
-    RoomQueryFilter
+    RoomQueryFilter,
+    RoomPayload
 )
 
 from .mini_program import (
@@ -351,5 +352,41 @@ class Puppet(ABC):
     async def contact_signature(self, signature: str):
         """
         change signature
+        """
+        raise NotImplementedError
+
+    async def room_validate(self, room_id: str) -> bool:
+        """
+        check if the room is validate
+        """
+        raise NotImplementedError
+
+    async def room_payload_dirty(self, room_id: str):
+        """
+        reset room dirty status
+        """
+        raise NotImplementedError
+
+    async def room_member_payload_dirty(self, room_id: str):
+        """
+        reset room member payload status
+        """
+        raise NotImplementedError
+
+    async def room_payload(self, room_id: str) -> Union[None, RoomPayload]:
+        """
+        get room payload
+        """
+        raise NotImplementedError
+
+    async def room_members(self, room_id: str) -> List[str]:
+        """
+        get room members
+        """
+        raise NotImplementedError
+
+    async def room_add(self, room_id: str, contact_id: str):
+        """
+        add contact to a room
         """
         raise NotImplementedError

--- a/src/wechaty_puppet/room.py
+++ b/src/wechaty_puppet/room.py
@@ -52,4 +52,4 @@ class RoomPayload:
         """
         initialization for room payload
         """
-        raise NotImplementedError
+        self.topic: str = None


### PR DESCRIPTION
**Problem**: When developer use wechaty to query room/contact/friendship,  they will use **QueryFilter from wechaty_puppet, so they should import wechaty_puppet too.

There is only one module that build a wrapper to QueryFilter class in ts wechaty . It's Message module that use MessageUserQueryFilter, so developer don't known wechaty_puppet MessageQueryFilter.

But I think MessageUserFilter is ugly. MessageQueryFilter is great and can be use in wechaty also.

**Solution**: Below is my simple code design.

```python
if TYPE_CHECKING:
    from wechaty_puppet import (
        FileBox,
        # So that RoomQueryFilter can be use in python-wechaty also
        RoomQueryFilter as PuppetRoomQueryFilter
    )

class RoomQueryFilter:
    """
    python-wechaty room query filter
    """
    def transfer(self) -> PuppetRoomQueryFilter:
        """
        # convert python-wechaty RoomQueryFilter to PuppetRoomQueryFilter
        """
        return PuppetRoomQueryFilter()

class Room(Accessory, Sayable):
    @classmethod
    async def find_all(cls, query: RoomQueryFilter = None) -> List[Room]:
        """
        find room by query filter
        """
        puppet_query = query.transfer() if query is not None else None
        room_ids = await cls.get_puppet().room_search(puppet_query)
        # do something
```