### PR TITLE
improve wechaty

### DIFF
--- a/src/wechaty/user/contact.py
+++ b/src/wechaty/user/contact.py
@@ -161,13 +161,14 @@ class Contact(Accessory, AsyncIOEventEmitter):
         load contact object from puppet
         :return:
         """
-        log.info('load contact %s', self.name)
+
         if force_sync or not self.is_ready():
             try:
                 payload = await self.puppet.contact_payload(
                     self.contact_id)
 
                 self.payload = payload
+                log.info('load contact <%s>', self)
             except IOError as e:
                 log.info('can"t load contact %s payload, message : %s',
                          self.name,
@@ -182,11 +183,11 @@ class Contact(Accessory, AsyncIOEventEmitter):
         if self.payload is None:
             return 'Contact <{}>'.format(self.contact_id)
 
-        if self.payload.name is not None:
-            identity = self.payload.name
-        elif self.payload.alias is not None:
+        if self.payload.alias.strip() != '':
             identity = self.payload.alias
-        elif self.contact_id is not None:
+        elif self.payload.name.strip() != '':
+            identity = self.payload.name
+        elif self.contact_id.strip() != '':
             identity = self.contact_id
         else:
             identity = 'loading ...'

--- a/src/wechaty/wechaty.py
+++ b/src/wechaty/wechaty.py
@@ -88,7 +88,7 @@ class WechatyOptions:
 
 
 # pylint:disable=R0902,R0904
-class Wechaty:
+class Wechaty(AsyncIOEventEmitter):
     """
     docstring
     """
@@ -105,7 +105,7 @@ class Wechaty:
         docstring
         """
         log.info('__init__()')
-
+        super().__init__()
         self.Tag = Tag
         self.Contact = Contact
         self.Friendship = Friendship
@@ -150,12 +150,15 @@ class Wechaty:
             return 'default_puppet'
         return self._name
 
-    def on(self, event: str, listener) -> Wechaty:
+    def on(self, event, f=None):
         """
-        listen event for puppet
+        listen wechaty event
+        :param event:
+        :param f:
+        :return:
         """
-        self.event_stream.on(event, listener)
-        return self
+        log.info('on() listen event <%s> with <%s>', event, f)
+        super().on(event, f)
 
     def emit(self, event_name: str, *args, **kwargs):
         """
@@ -163,130 +166,107 @@ class Wechaty:
         """
         self.event_stream.emit(event_name, *args, **kwargs)
 
-    def on_dong(self, listener: Callable[[str], None]) -> Wechaty:
-        """
-        listen dong event for puppet
-
-        this is friendly for code typing
-        """
-        self.event_stream.on('dong', listener)
-        return self
-
-    def on_error(self, listener: Callable[[str], None]) -> Wechaty:
+    async def on_error(self, payload: EventErrorPayload):
         """
         listen error event for puppet
 
         this is friendly for code typing
         """
-        self.event_stream.on('error', listener)
+        pass
 
-        return self
-
-    def on_heartbeat(self, listener: Callable[[str], None]) -> Wechaty:
+    async def on_heartbeat(self, payload: EventHeartbeatPayload):
         """
         listen heartbeat event for puppet
 
         this is friendly for code typing
         """
-        self.event_stream.on('heartbeat', listener)
+        pass
 
-        return self
-
-    def on_friendship(self, listener: Callable[[Friendship], None]) -> Wechaty:
+    async def on_friendship(self, friendship: Friendship):
         """
         listen friendship event for puppet
 
         this is friendly for code typing
         """
-        self.event_stream.on('friendship', listener)
-        return self
+        pass
 
-    def on_login(self, listener: Callable[[Contact], None]) -> Wechaty:
+    async def on_login(self, contact: Contact):
         """
         listen login event for puppet
 
         this is friendly for code typing
         """
-        self.event_stream.on('login', listener)
-        return self
+        pass
 
-    def on_logout(self, listener: Callable[[str], None]) -> Wechaty:
+    async def on_logout(self, contact: Contact):
         """
         listen logout event for puppet
 
         this is friendly for code typing
         """
-        self.event_stream.on('logout', listener)
-        return self
+        pass
 
-    def on_message(self, listener: Callable[[Message], None]) -> Wechaty:
+    async def on_message(self, msg: Message):
         """
         listen message event for puppet
 
         this is friendly for code typing
         """
-        self.event_stream.on('message', listener)
-        return self
+        pass
 
-    def on_ready(self, listener: Callable[[None], None]) -> Wechaty:
+    async def on_ready(self):
         """
         listen ready event for puppet
 
         this is friendly for code typing
         """
-        self.event_stream.on('ready', listener)
-        return self
+        pass
 
-    def on_room_invite(self, listener: Callable[[RoomInvitation], None]
-                       ) -> Wechaty:
+    async def on_room_invite(self, room_invitation: RoomInvitation):
         """
         listen room_invitation event for puppet
 
         this is friendly for code typing
         """
-        self.event_stream.on('room_invite', listener)
-        return self
+        pass
 
-    def on_room_join(self,
-                     listener: Callable[[Room, List[Contact],
-                                         Contact, datetime], None]) -> Wechaty:
+    async def on_room_join(self, room: Room, invitees: List[Contact],
+                     inviter: Contact, date: datetime):
         """
         listen room_join event for puppet
 
         this is friendly for code typing
         """
-        self.event_stream.on('room_join', listener)
-        return self
+        pass
 
-    def on_room_leave(self, listener: Callable[[Room, List[Contact], Contact,
-                                                datetime], None]) -> Wechaty:
+    async def on_room_leave(self, room: Room, leavers: List[Contact],
+                      remover: Contact, date: datetime):
         """
         listen room_leave event for puppet
 
+        room, leavers, remover, date
+
         this is friendly for code typing
         """
-        self.event_stream.on('room_leave', listener)
-        return self
+        pass
 
-    def on_room_topic(self, listener: Callable[[Room, str, str, Contact,
-                                                datetime], None]) -> Wechaty:
+    async def on_room_topic(self, room: Room, new_topic: str, old_topic: str,
+                      changer: Contact, date: datetime):
         """
         listen room_topic event for puppet
 
         this is friendly for code typing
         """
-        self.event_stream.on('room_topic', listener)
-        return self
+        pass
 
-    def on_scan(self, listener: Callable[[str, ScanStatus, str], None]
-                ) -> Wechaty:
+    async def on_scan(self, status: ScanStatus, qr_code: Optional[str] = None,
+                data: Optional[str] = None):
         """
         listen scan event for puppet
 
         this is friendly for code typing
         """
-        self.event_stream.on('scan', listener)
-        return self
+        pass
 
     async def start(self):
         """
@@ -347,6 +327,7 @@ class Wechaty:
             elif event_name == 'error':
                 def error_listener(payload: EventErrorPayload):
                     self.event_stream.emit('error', payload)
+                    self.on_error(payload)
 
                 puppet.on('error', error_listener)
 

--- a/src/wechaty_puppet/__init__.py
+++ b/src/wechaty_puppet/__init__.py
@@ -70,6 +70,8 @@ from .schemas.mini_program import MiniProgramPayload
 
 from .schemas.event import (
     EventScanPayload,
+    ScanStatus,
+
     EventDongPayload,
     EventLoginPayload,
     EventReadyPayload,
@@ -118,6 +120,8 @@ __all__ = [
     'MiniProgramPayload',
 
     'EventScanPayload',
+    'ScanStatus',
+
     'EventDongPayload',
     'EventLoginPayload',
     'EventReadyPayload',

--- a/src/wechaty_puppet/schemas/event.py
+++ b/src/wechaty_puppet/schemas/event.py
@@ -24,8 +24,6 @@ from enum import Enum
 from dataclasses import dataclass
 from typing import List, Optional
 
-from wechaty_puppet import MessageType
-
 
 class ScanStatus(Enum):
     """
@@ -107,7 +105,7 @@ class EventRoomTopicPayload(EventPayloadBase):
 @dataclass
 class EventScanPayload(EventPayloadBase):
     status: ScanStatus
-    qr_code: Optional[str] = None
+    qrcode: Optional[str] = None
     data: Optional[str] = None
 
 

--- a/src/wechaty_puppet/watch_dog.py
+++ b/src/wechaty_puppet/watch_dog.py
@@ -74,7 +74,7 @@ class Watchdog(AsyncIOEventEmitter):
 
     def feed(self, food: WatchdogFood):
         """feed the food to the watch dog"""
-        log.info('feed the food <%s> the watchdog', food)
+        log.debug('feed the food <%s> the watchdog', food)
         self._last_food = food
         self._last_feed = datetime.now()
         self.emit('feed', food, self._last_feed)

--- a/src/wechaty_puppet_hostie/puppet.py
+++ b/src/wechaty_puppet_hostie/puppet.py
@@ -35,6 +35,8 @@ from pyee import AsyncIOEventEmitter  # type: ignore
 
 from wechaty_puppet import (
     EventScanPayload,
+    ScanStatus,
+
     EventReadyPayload,
 
     EventDongPayload,
@@ -77,9 +79,6 @@ class HostiePuppet(Puppet):
         self.channel, self.puppet_stub = self.init_puppet()
 
         self._event_stream: AsyncIOEventEmitter = AsyncIOEventEmitter()
-
-        self.init_puppet()
-        # self.puppet_stub.room_member_list()
 
     async def room_list(self) -> List[str]:
         """
@@ -683,12 +682,15 @@ class HostiePuppet(Puppet):
         log.info('listening the event from the puppet ...')
         async for response in self.puppet_stub.event():
             if response is not None:
-                log.info('receive event: <%s>', response)
                 payload_data: dict = json.loads(response.payload)
                 if response.type == int(EventType.EVENT_TYPE_SCAN):
                     log.debug('receiving scan info <%s>', response)
                     # create qr_code
-                    payload = EventScanPayload(**payload_data)
+                    payload = EventScanPayload(
+                        status=ScanStatus(payload_data['status']),
+                        qrcode=payload_data.get('qrcode', None),
+                        data=payload_data.get('data', None)
+                    )
                     self._event_stream.emit('scan', payload)
 
                 elif response.type == int(EventType.EVENT_TYPE_DONG):


### PR DESCRIPTION
improve wechaty implementation. There will be some changes:
- [x] inherit from `AsyncIOEventEmitter`
- [x] support two ways to write wechaty bot.


```python
async def message(msg: Message):
    # do something

bot = Wechaty(hostie_puppet).on('message', message)
await bot.start()
```
This is the classic `callback` program method. But there are many developers who are familiar with  `oop` that they will get abrupted about this way. So, I add some `on_event_name` functions which only need to be overrided.

```python
class MyWechaty(Wechaty):
    def __init__(token: str):
        hostie_puppet = ...
        super().__init__(hostie_puppet)

    async def on_message(self, msg: Message):
        # do something
bot = MyWechaty(token)
await bot.start()
```
Both methods can work fine. 