### PR TITLE
🚀 import types & fix log handler & fix friendship payload type

### DIFF
--- a/src/wechaty/__init__.py
+++ b/src/wechaty/__init__.py
@@ -1,8 +1,46 @@
 """doc"""
 
+#
+# import types from wechaty_puppet
+#
+
 from wechaty_puppet import (    # type: ignore
     FileBox,
+    MessageType,
+    MessagePayload,
+
+    # Contact
+    ContactGender,
+    ContactType,
+    ContactPayload,
+
+    # Friendship
+    FriendshipType,
+    FriendshipPayload,
+
+    # Room
+    RoomPayload,
+    RoomMemberPayload,
+
+    # UrlLink
+
+    # RoomInvitation
+    RoomInvitationPayload,
+
+    # Image
+    ImageType,
+
+    # Event
+    EventType,
+
+    RoomQueryFilter,
+    RoomMemberQueryFilter,
+    FriendshipSearchQueryFilter,
+    ContactQueryFilter,
+    MessageQueryFilter,
 )
+
+
 from .config import (
     get_logger,
 )
@@ -23,6 +61,7 @@ from .user import (
     UrlLink,
 )
 
+
 __all__ = [
     'Accessory',
     'Contact',
@@ -38,4 +77,38 @@ __all__ = [
     'UrlLink',
     'Wechaty',
     'WechatyOptions',
+
+    'MessageType',
+    'MessagePayload',
+
+    # Contact
+    'ContactGender',
+    'ContactType',
+    'ContactPayload',
+
+    # Friendship
+    'FriendshipType',
+    'FriendshipPayload',
+
+    # Room
+    'RoomPayload',
+    'RoomMemberPayload',
+
+    # UrlLink
+
+    # RoomInvitation
+    'RoomInvitationPayload',
+
+    # Image
+    'ImageType',
+
+    # Event
+    'EventType',
+
+    'RoomQueryFilter',
+    'RoomMemberQueryFilter',
+    'FriendshipSearchQueryFilter',
+    'ContactQueryFilter',
+    'MessageQueryFilter',
+    'FileBox'
 ]

--- a/src/wechaty/config.py
+++ b/src/wechaty/config.py
@@ -57,6 +57,19 @@ def get_logger(name: str) -> logging.Logger:
     _log = logging.getLogger(name)
     _log.setLevel(level)
 
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.DEBUG)
+
+    # create formatter
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+    # add formatter to ch
+    handler.setFormatter(formatter)
+
+    # add ch to logger
+    _log.addHandler(handler)
+
     return _log
 
 

--- a/src/wechaty/wechaty.py
+++ b/src/wechaty/wechaty.py
@@ -136,7 +136,7 @@ class Wechaty(AsyncIOEventEmitter):
     def _load_puppet(options: WechatyOptions) -> Puppet:
         """
         dynamic load puppet
-        :param puppet_options:
+        :param options:
         :return:
         """
         if options.puppet is None:
@@ -387,9 +387,9 @@ class Wechaty(AsyncIOEventEmitter):
                     log.info('receive <friendship> event <%s>', payload)
                     friendship = self.Friendship.load(payload.friendship_id)
                     await friendship.ready()
-                    self.emit('friendship', payload)
+                    self.emit('friendship', friendship)
                     friendship.contact().emit('friendship', friendship)
-                    await self.on_friendship(payload)
+                    await self.on_friendship(friendship)
 
                 puppet.on('friendship', friendship_listener)
 


### PR DESCRIPTION
fix fllowing problems : 
- there are no log output at console, because of no handler, [python-logging-setlevel-not-taking-effect](https://stackoverflow.com/questions/39794194/python-logging-setlevel-not-taking-effect)
- import types which is from `wechaty-puppet`  can be imported from `wechaty`.
- fix friendship emit event params bugs.