### PR TITLE
Feat/issue#140 git hook with pre-push/pre-comit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,58 @@
+# the hook execution directory in under git root directory
+repos:
+- repo: local
+  hooks:
+
+  - id: pylint
+    name: pylint
+    description: "Pylint: Checks for errors in Python code"
+    language: system
+    entry: make pylint
+    require_serial: true
+    stages: [push]
+    types: [python]
+
+  - id: pycodestyle
+    name: pycodestyle
+    description: "pycodestyle: Check your Python code against styles conventions in PEP 8"
+    language: system
+    entry: make pycodestyle
+    require_serial: true
+    stages: [push]
+    types: [python]
+
+  - id: flake8
+    name: flake8
+    description: "flake8: Tool For Style Guide Enforcement"
+    language: system
+    entry: make flake8
+    require_serial: true
+    stages: [push]
+    types: [python]
+
+  - id: mypy
+    name: mypy
+    description: "mypy: an optional static type checker for Python"
+    language: system
+    entry: make mypy
+    require_serial: true
+    stages: [push]
+    types: [python]
+
+  - id: pytype
+    name: pytype
+    description: "pytype: checks and infers types for your Python code"
+    language: system
+    entry: make pytype
+    require_serial: true
+    stages: [push]
+    types: [python]
+
+  - id: pytest
+    name: pytest
+    description: "pytest: run python pytest unit test"
+    language: system
+    entry: make pytest
+    require_serial: true
+    stages: [push]
+    types: [python]

--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,29 @@ pytype:
 	pytype src/ --disable=import-error,pyi-error
 	pytype examples/ --disable=import-error
 
+.PHONY: uninstall-git-hook
+uninstall-git-hook:
+	pre-commit clean
+	pre-commit gc
+	pre-commit uninstall
+	pre-commit uninstall --hook-type pre-push
+
+.PHONY: install-git-hook
+install-git-hook:
+	# cleanup existing pre-commit configuration (if any)
+	pre-commit clean
+	pre-commit gc
+	# setup pre-commit
+	# Ensures pre-commit hooks point to latest versions
+	pre-commit autoupdate
+	pre-commit install
+	pre-commit install --hook-type pre-push
+
 .PHONY: install
 install:
 	pip3 install -r requirements.txt
 	pip3 install -r requirements-dev.txt
+	$(MAKE) install-git-hook
 
 .PHONY: pytest
 pytest:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,4 @@ requests
 qrcode
 apscheduler
 lxml
+pre-commit


### PR DESCRIPTION
currently, we don't use pre-commit method, and we only use pre-push.
I use Makefile to execute these hook that we can make sure all configuration is isolated with all linter we have.

Here is the sample output when the developers tried to do a push
```
(wechaty-py3.7) [±feat/issue#140-git-hook •]$ git push --set-upstream origin feat/issue#140-git-hook
Pseudo-terminal will not be allocated because stdin is not a terminal.
Enter passphrase for key '/Users/william/.ssh/id_rsa': 
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /Users/william/.cache/pre-commit/patch1601245172.
pylint...............................................(no files to check)Skipped
pycodestyle..........................................(no files to check)Skipped
flake8...............................................(no files to check)Skipped
mypy.................................................(no files to check)Skipped
pytype...............................................(no files to check)Skipped
pytest...............................................(no files to check)Skipped
[INFO] Restored changes from /Users/william/.cache/pre-commit/patch1601245172.
Enumerating objects: 10, done.
Counting objects: 100% (10/10), done.
Delta compression using up to 12 threads
Compressing objects: 100% (7/7), done.
Writing objects: 100% (7/7), 1.27 KiB | 1.27 MiB/s, done.
Total 7 (delta 4), reused 0 (delta 0)
remote: Resolving deltas: 100% (4/4), completed with 3 local objects.
remote: 
remote: Create a pull request for 'feat/issue#140-git-hook' on GitHub by visiting:
remote:      https://github.com/kis87988/wechaty-python-wechaty/pull/new/feat/issue%23140-git-hook
remote: 
To github.com:kis87988/wechaty-python-wechaty.git
 * [new branch]      feat/issue#140-git-hook -> feat/issue#140-git-hook
Branch 'feat/issue#140-git-hook' set up to track remote branch 'feat/issue#140-git-hook' from 'origin' by rebasing.
```