### PR TITLE
invert the ASCII characters of terminal QR code

### DIFF
--- a/src/wechaty/utils/qr_code.py
+++ b/src/wechaty/utils/qr_code.py
@@ -2,7 +2,6 @@
 """
 qr_code helper utils
 """
-import platform
 from typing import Any
 import qrcode
 
@@ -22,4 +21,4 @@ def qr_terminal(data: str, version: Any = None) -> None:
         qr.make()
     else:
         qr.make(fit=True)
-    qr.print_ascii()
+    qr.print_ascii(invert=True)


### PR DESCRIPTION
Signed-off-by: doublewinter0 <erdong.me@gmail.com>

**use `qr.print_ascii()`, QR code like this:**
![image](https://user-images.githubusercontent.com/22414051/177557843-a3348708-9bbd-4748-bb1f-80276017b692.png)

**use `qr.print_ascii(invert=True)`, QR code like this:**
![image](https://user-images.githubusercontent.com/22414051/177558551-a7def2f7-168c-402e-a99b-1bb1493cdde1.png)

**WeChat official QR code like this:**
![image](https://user-images.githubusercontent.com/22414051/177559612-70082d8d-0671-40fe-ba12-66b8b1ef41c1.png)

So I think the QR code experience with character inversion is a little better