### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ Quart-CORS
 APScheduler
 SQLAlchemy
 PyGithub
+markupsafe==2.0.1


### PR DESCRIPTION
The lib `markupsafe`  has deprecated the method `soft_unicode` since `2.1.0`. So `2.0.1` version is recommended.

It will cause the error below:
```
    from .debug import traceback_response
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/quart/debug.py", line 6, in <module>
    from jinja2 import Template
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/home/ubuntu/anaconda3/lib/python3.8/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/home/ubuntu/anaconda3/lib/python3.8/site-packages/markupsafe/__init__.py)

```