### PR TITLE
Fix puppet not set issue in RoomInvitation

### DIFF
--- a/src/wechaty/user/room_invitation.py
+++ b/src/wechaty/user/room_invitation.py
@@ -91,8 +91,7 @@ class RoomInvitation(Accessory, Acceptable):
         """
         log.info('load () <%s>', room_invitation_id)
 
-        invitation = RoomInvitation(room_invitation_id)
-        return invitation
+        return cls(room_invitation_id)
 
     async def accept(self) -> None:
         """


### PR DESCRIPTION
### Issue

Whenever operations related to room invitations were performed, an error `<puppet not set>` occurred. After tracing the root of the problem, it was identified that the `load` method in the `RoomInvitation` class was not correctly associating the puppet with the new instance of `RoomInvitation`.

Further details can be found in the related issue: [Issue #354](https://github.com/wechaty/python-wechaty/issues/354).

### Solution

Adjusted the `load` method in the `RoomInvitation` class. The method was previously creating a new instance of `RoomInvitation` without correctly setting up the puppet. By using the `cls` method for instantiation, we ensure that the puppet is properly associated with the `RoomInvitation` object.

### Changes
- Refactored the `load` method in the `RoomInvitation` class to utilize `cls` for instantiation, ensuring the puppet is set correctly.

Please review these changes and let me know if further adjustments are required.

Thank you!
