### PR TITLE
fix: address issue causing failure to receive heartbeat

### DIFF
--- a/src/wechaty/user/contact.py
+++ b/src/wechaty/user/contact.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
     # pytype: disable=pyi-error
     from .url_link import UrlLink
     from .mini_program import MiniProgram
-    
+
 
 log = get_logger('Contact')
 
@@ -190,7 +190,7 @@ class Contact(Accessory[ContactPayload], AsyncIOEventEmitter):
 
         Args:
             query: the query body to build filter
-            
+
         Examples:
             >>> # 1. find contacts based query string, will match one of: contact_id, weixin, name and alias
             >>> # what's more, contact_id and weixin will follow extract match, name and alias will follow fuzzy match
@@ -319,7 +319,7 @@ class Contact(Accessory[ContactPayload], AsyncIOEventEmitter):
 
         Args:
             message: the message object to be sended to contact
-        
+
         Examples:
             >>> contact = Contact.load('contact-id')
             >>> await contact.say('hello')
@@ -331,7 +331,7 @@ class Contact(Accessory[ContactPayload], AsyncIOEventEmitter):
             >>> await contact.say(MiniProgram('username', 'appid'))
 
         Returns:
-            Message: if the message is send successfully, return the message object, otherwise return None 
+            Message: if the message is send successfully, return the message object, otherwise return None
         """
         if not message:
             log.error('can"t say nothing')
@@ -360,7 +360,7 @@ class Contact(Accessory[ContactPayload], AsyncIOEventEmitter):
                 conversation_id=self.contact_id,
                 file=message
             )
-
+            return None
         elif isinstance(message, UrlLink):
             # use this way to resolve circulation dependency import
             msg_id = await self.puppet.message_send_url(
@@ -390,7 +390,7 @@ class Contact(Accessory[ContactPayload], AsyncIOEventEmitter):
         Examples:
             >>> contact = Contact.load('contact-id')
             >>> name: str = contact.name
-        
+
         Returns:
             str: name of contact, if the payload is None, return empty string
         """
@@ -403,7 +403,7 @@ class Contact(Accessory[ContactPayload], AsyncIOEventEmitter):
                     ) -> Union[None, str]:
         """
         Get or set alias of contact.
-        
+
         If new_alias is given, it will set alias to new_alias,
         otherwise return current alias
 
@@ -527,7 +527,7 @@ class Contact(Accessory[ContactPayload], AsyncIOEventEmitter):
     def gender(self) -> ContactGender:
         """
         Return the gender of contact.
-        
+
         Returns:
             ContactGender: the object of contact gender
         """
@@ -571,7 +571,7 @@ class Contact(Accessory[ContactPayload], AsyncIOEventEmitter):
         Args:
             file_box: If given, it will set it as new avatar,
                 else get the current avatar. Defaults to None.
-        
+
         Examples:
             >>> contact = Contact.load('contact-id')
             >>> avatar = contact.avatar()
@@ -627,7 +627,7 @@ class Contact(Accessory[ContactPayload], AsyncIOEventEmitter):
         Examples:
             >>> contact = Contact.load('contact-id')
             >>> weixin = contact.weixin()
-            
+
         Returns:
             identifier: the weixin union identifier of contact
         """

--- a/src/wechaty/wechaty.py
+++ b/src/wechaty/wechaty.py
@@ -530,7 +530,7 @@ I suggest that you should follow the template code from: https://wechaty.readthe
                     self.emit('heartbeat', payload.data)
                     await self.on_heartbeat(payload)
 
-                puppet.on('heart-beat', heartbeat_listener)
+                puppet.on('heartbeat', heartbeat_listener)
 
             elif event_name == 'friendship':
                 async def friendship_listener(payload: EventFriendshipPayload) -> None:


### PR DESCRIPTION
Rename 'heart-beat' to 'heartbeat' to align with emit in puppet.py:1017.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes heartbeat event listener in `wechaty.py` by renaming event from `'heart-beat'` to `'heartbeat'`.
> 
>   - **Behavior**:
>     - Fixes issue with heartbeat event listener in `wechaty.py` by renaming event from `'heart-beat'` to `'heartbeat'` to match the emitted event name.
>   - **Misc**:
>     - Aligns event naming convention in `wechaty.py` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wechaty%2Fpython-wechaty&utm_source=github&utm_medium=referral)<sup> for a118af103ef43b036ba5b7178e0ef579aaeb0264. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the event name for the heartbeat event to ensure consistent and reliable event handling.
	- Improved message handling by explicitly returning after sending a file message.
- **New Features**
	- Added an option to force synchronization when loading and preparing room data, ensuring the latest information is retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->